### PR TITLE
fixed #6

### DIFF
--- a/tasks/jsx.js
+++ b/tasks/jsx.js
@@ -17,7 +17,14 @@ module.exports = function(grunt) {
         }
       });
 
-      existFiles.map(function(filepath) {
+      var resultcode = true;
+      existFiles.push(null); // Sentinel
+      grunt.util.async.forEachSeries(existFiles, function(filepath, next) {
+        if (filepath === null)
+        {
+          done(resultcode);
+          return;
+        }
         compileJsx(
           filepath,
           {
@@ -43,7 +50,8 @@ module.exports = function(grunt) {
             if (!error) {
               grunt.log.ok();
             }
-            done(!code);
+            resultcode = !code && resultcode;
+            next();
           });
       });
     });


### PR DESCRIPTION
Issue 6の修正コードです。
- 既存のコードは複数のタスクがあるときに全部同時並行で実行し、最初のコンパイルが終わった時点の終了コードを返している(終わってなかったタスクは破棄される？)
- テストのソースが複数ある場合は結果が混じっていた可能性も・・・
- async.forEachSeriesを使ってひとつずつタスクを実行するようにしました(動作は遅くなってしまいますが)。
- 同時オープン数(入力ファイル数)が11を超えた時のパイプのlistenerの警告も解消しています。
