### PR TITLE
Fix bug tests don't run when test:true

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,11 @@ module.exports = function(grunt) {
       gruntfile: {
         src: 'Gruntfile.js'
       },
-      jsx: {
+      task: {
         src: 'tasks/jsx.js'
+      },
+      core: {
+        src: 'lib/jsx.js'
       }
     },
     watch: {
@@ -34,6 +37,9 @@ module.exports = function(grunt) {
         actuals: ['tmp/*.js', 'tmp/template/fixtures/template.jsx.html'],
         expected: ['fixtures/expected/*.js', 'fixtures/expected/template/fixtures/template.jsx.html']
       }
+    },
+    unittest: {
+      core: {}
     },
     jsx: {
       client: {
@@ -148,6 +154,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
 
   // Default task.
-  grunt.registerTask('test', ['clean', 'jsx', 'checkfile']);
+  grunt.registerTask('test', ['unittest', 'clean', 'jsx', 'checkfile']);
   grunt.registerTask('default', ['jshint', 'watch']);
 };

--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -1,0 +1,71 @@
+
+function changeExt (file, opts) {
+  var output = file;
+  if (file.lastIndexOf('.') !== -1) {
+    output = file.slice(0, file.lastIndexOf('.'));
+  }
+  if (opts.ext) {
+    output = output + opts.ext;
+  }
+  else if (opts.test) {
+    output = undefined;
+  }
+  else if (!opts.executable || opts.executable !== 'node') {
+    output = output + '.js';
+  }
+  return output;
+}
+
+/**
+ * Creates option
+ */
+function finalizeJsxOption (grunt, file, opts, isDir) {
+  var path = require('path');
+  var _ = grunt.util._;
+  if (!file) {
+    grunt.log.warn('Source file is undefiend.');
+    callback("No file", null, 1);
+  }
+  var args = opts.args ? opts.args.split(" ") : [];
+  var output_rule = opts.output_rule;
+
+  if (!opts.output) {
+    if (output_rule) {
+      //need output
+      opts.output = file.replace(output_rule.regexp, output_rule.replace);
+    }
+    else if (!opts.test) {
+      opts.output = changeExt(file, opts);
+    }
+  }
+  else if (isDir(opts.output) && !opts.test) {
+    opts.output = changeExt(path.resolve(opts.output, file.slice(file.lastIndexOf('/') + 1)), opts);
+  }
+
+  delete opts.args;
+  delete opts.output_rule;
+  delete opts.ext;
+
+  _.each(opts, function(value, key) {
+    if(value && value !== true) {
+      if (_.isArray(value)) {
+        _.each(value, function(v) {
+          args.push("--"+key, v);
+        });
+      }
+      else {
+        args.push("--"+key, value);
+      }
+    }
+    else if(value === true) {
+      args.push("--"+key);
+    }
+  });
+  args.push(file);
+  return args;
+}
+
+module.exports = {
+  changeExt: changeExt,
+  finalizeJsxOption: finalizeJsxOption
+};

--- a/tasks/jsx.js
+++ b/tasks/jsx.js
@@ -1,8 +1,10 @@
 module.exports = function(grunt) {
   'use strict';
-  var path = require('path');
+  var finalizeJsxOption = require('../lib/jsx.js').finalizeJsxOption;
   var _ = grunt.util._;
+
   grunt.registerMultiTask('jsx', 'Compile JSX file to JavaScript', function() {
+      try {
     var done = this.async();
     this.files.forEach(function(file) {
       if (file.src.length < 1) {
@@ -24,99 +26,42 @@ module.exports = function(grunt) {
           done(resultcode);
           return;
         }
-        compileJsx(
-          filepath,
-          {
-            output: file.dest,
-            executable: file.executable,
-            release: file.release,
-            "add-search-path": file.add_search_path,
-            "enable-source-map": file.enable_source_map,
-            profile: file.profile,
-            minify: file.minify,
-            optimize: file.optimize,
-            "disable-optimize": file.disable_optimize,
-            warn: file.warn,
-            "disable-type-check": file.disable_type_check,
-            mode: file.mode,
-            target: file.target,
-            test: file.test,
-            args: file.args,
-            output_rule : file.output_rule,
-            ext: file.ext
-          },
-          function(error, result, code) {
-            if (!error) {
-              grunt.log.ok();
-            }
-            resultcode = !code && resultcode;
-            next();
-          });
+        var opts = {
+          output: file.dest,
+          executable: file.executable,
+          release: file.release,
+          "add-search-path": file.add_search_path,
+          "enable-source-map": file.enable_source_map,
+          profile: file.profile,
+          minify: file.minify,
+          optimize: file.optimize,
+          "disable-optimize": file.disable_optimize,
+          warn: file.warn,
+          "disable-type-check": file.disable_type_check,
+          mode: file.mode,
+          target: file.target,
+          test: file.test,
+          args: file.args,
+          output_rule : file.output_rule,
+          ext: file.ext
+        };
+        var args = finalizeJsxOption(grunt, filepath, opts, grunt.file.isDir);
+        grunt.log.write('jsx ');
+        grunt.log.writeln(args.join(" "));
+        grunt.util.spawn({
+          cmd: 'jsx',
+          args: args,
+          opts: { stdio : ['ignore', process.stdout, process.stderr] }
+        }, function (error, result, code) {
+          if (!error) {
+            grunt.log.ok();
+          }
+          resultcode = !code && resultcode;
+          next();
+        });
       });
     });
+      } catch (e) { console.log(e.stack); }
   });
-
-  var changeExt = function (file, ext, opts) {
-    var output = file;
-    if (file.lastIndexOf('.') !== -1) {
-      output = file.slice(0, file.lastIndexOf('.'));
-    }
-    if (ext) {
-      output = output + ext;
-    }
-    else if (!opts.executable || opts.executable !== 'node') {
-      output = output + '.js';
-    }
-    return output;
-  };
-
-  var compileJsx = function (file, opts, callback) {
-    if (!file) {
-      grunt.log.warn('Source file is undefiend.');
-      callback("No file", null, 1);
-    }
-    var args = opts.args ? opts.args.split(" ") : [];
-    var output_rule = opts.output_rule;
-    var ext = opts.ext;
-    delete opts.args;
-    delete opts.output_rule;
-    delete opts.ext;
-
-    if (!opts.output) {
-      if (output_rule) {
-        //need output
-        opts.output = file.replace(output_rule.regexp, output_rule.replace);
-      }
-      else if (!opts.test) {
-        opts.output = changeExt(file, ext, opts);
-      }
-    }
-    else if (grunt.file.isDir(opts.output) && !opts.test) {
-      opts.output = changeExt(path.resolve(opts.output, file.slice(file.lastIndexOf('/') + 1)), ext, opts);
-    }
-
-    _.each(opts, function(value, key) {
-      if(value && value !== true) {
-        if (_.isArray(value)) {
-          _.each(value, function(v) {
-            args.push("--"+key, v);
-          });
-        }
-        else {
-          args.push("--"+key, value);
-        }
-      }
-      else if(value === true) {
-        args.push("--"+key);
-      }
-    });
-    args.push(file);
-    grunt.log.write('jsx ');
-    grunt.log.writeln(args.join(" "));
-    var jsx = grunt.util.spawn({
-      cmd: 'jsx',
-      args: args,
-      opts: { stdio : ['ignore', process.stdout, process.stderr] }
-    }, callback);
-  };
 };
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,10 @@
 var expect = require('expect.js');
+var jsx = require('../lib/jsx.js');
 
 module.exports = function(grunt) {
   'use strict';
   var _ = grunt.util._;
+
   function assertFileEquality(pathToActual, pathToExpected) {
     var actual = grunt.file.read(pathToActual).replace(/\/\/.+\n/g, "");
     // remove error message,
@@ -16,6 +18,7 @@ module.exports = function(grunt) {
     console.log(pathToActual, pathToExpected);
     expect(actual).to.eql(expected);
   }
+
   grunt.registerMultiTask('checkfile', 'check equality', function() { 
     var testConfig = grunt.config('checkfile');
     var actuals = grunt.file.expand(testConfig.test.actuals);
@@ -24,5 +27,25 @@ module.exports = function(grunt) {
     for (var i=0; i<expected.length; i++) {
       assertFileEquality(actuals[i], expected[i]);
     }
+  });
+
+  grunt.registerMultiTask('unittest', 'unit test for grunt.jsx', function() {
+    expect(jsx.changeExt('test.jsx', {ext: '.jsfl'})).to.be('test.jsfl');
+    expect(jsx.changeExt('test.jsx', {executable: 'node'})).to.be('test');
+    expect(jsx.changeExt('test.jsx', {executable: 'web'})).to.be('test.js');
+    expect(jsx.changeExt('test.jsx', {executable: undefined})).to.be('test.js');
+    expect(jsx.changeExt('test.jsx', {test: true})).to.be(undefined);
+
+    function trueFunc() { return true; }
+    function falseFunc() { return true; }
+
+    var args = jsx.finalizeJsxOption(grunt, 'dir/test.jsx', {}, trueFunc); // is dir = true
+    expect(args.indexOf('dir/test.js')).not.to.be(-1);
+
+    var args = jsx.finalizeJsxOption(grunt, 'dir/test.jsx', {test: true}, trueFunc); // is dir = true
+    expect(args.indexOf('--output')).to.be(-1);
+
+    var args = jsx.finalizeJsxOption(grunt, 'dir/test.jsx', {executable: 'node'}, trueFunc); // is dir = true
+    expect(args.indexOf('dir/test')).not.to.be(-1);
   });
 };


### PR DESCRIPTION
JSXは--test時に、--outputを同時に指定するとテストが実行しないことがわかりました。

前回の拡張子自動補完のコードのせいで、outputが省略しても追加されてしまうため、テストが実行されません。僕のバグです。すみません。

あと、テストコードですが、--testをつけるとアウトプットが出ないので、今あるテストコードだと比較ができません。バックドアを付けて、このオプションを渡したら、最終的にJSXにこういうパラメータが渡る、みたいなテストを追加してもいいですか？
